### PR TITLE
Fix signal icon is not shown

### DIFF
--- a/src/java/com/android/internal/telephony/ServiceStateTracker.java
+++ b/src/java/com/android/internal/telephony/ServiceStateTracker.java
@@ -4289,7 +4289,7 @@ public class ServiceStateTracker extends Handler {
      * @return true if the signal strength changed and a notification was sent.
      */
     protected boolean onSignalStrengthResult(AsyncResult ar) {
-        boolean isGsm = false;
+        boolean isGsm = mPhone.isPhoneTypeGsm();
         int dataRat = mSS.getRilDataRadioTechnology();
         int voiceRat = mSS.getRilVoiceRadioTechnology();
 


### PR DESCRIPTION
The flag GSM of signal strength is set as false under OOS, if lower
layer does not notify signal strength again after in-service, the
signal level is based on CDMA, so that signal icon is unable to be
shown.

To fix it, change the preset flag GSM based on phone type.

Change-Id: I98a84f8701cbd4da9f9896d400048db733a224de